### PR TITLE
使用爱词霸在线翻译取代不可用的百度在线翻译

### DIFF
--- a/classify_image.py
+++ b/classify_image.py
@@ -167,7 +167,10 @@ def run_inference_on_image(image):
       human_string = node_lookup.id_to_string(node_id)
       score = predictions[node_id]
       try:
-        print('%s(%s)---(Matching = %.5f)' % (human_string, iciba('Also known as ' + human_string, dst='zh').encode('utf-8'), score))
+        human_string_zh = iciba('Also known as ' + human_string, dst='zh')
+        if sys.version_info.major <= 2:
+          human_string_zh = human_string_zh.encode('utf-8')
+        print('%s(%s)---(Matching = %.5f)' % (human_string, human_string_zh, score))
       except (TranslateError, ConnectError):
         print('%s---(Matching = %.5f)' % (human_string, score))
 

--- a/classify_image.py
+++ b/classify_image.py
@@ -168,7 +168,7 @@ def run_inference_on_image(image):
       score = predictions[node_id]
       try:
         print('%s(%s)---(Matching = %.5f)' % (human_string, iciba('Also known as ' + human_string, dst='zh').encode('utf-8'), score))
-      except TranslateError, ConnectError:
+      except (TranslateError, ConnectError):
         print('%s---(Matching = %.5f)' % (human_string, score))
 
 

--- a/classify_image.py
+++ b/classify_image.py
@@ -45,7 +45,7 @@ import tarfile
 import numpy as np
 from six.moves import urllib
 import tensorflow as tf
-from translation import baidu, google, youdao, iciba
+from translation import baidu, google, youdao, iciba, TranslateError, ConnectError
 import fileinput
 FLAGS = None
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -166,7 +166,10 @@ def run_inference_on_image(image):
     for node_id in top_k:
       human_string = node_lookup.id_to_string(node_id)
       score = predictions[node_id]
-      print('%s(%s)---(Matching = %.5f)' % (human_string,baidu(human_string,dst='zh').encode('utf-8'), score))
+      try:
+        print('%s(%s)---(Matching = %.5f)' % (human_string, iciba('Also known as ' + human_string, dst='zh').encode('utf-8'), score))
+      except TranslateError, ConnectError:
+        print('%s---(Matching = %.5f)' % (human_string, score))
 
 
 def maybe_download_and_extract():


### PR DESCRIPTION
经测试: python的translation长期无人维护, 目前只有iciba提供的API接口目前勉强能用, google需要科学上网, baidu, bing和youdao可能关闭或修改了API入口, 
```
from translation import baidu, google, youdao, iciba
```

另外, 添加一个 try-catch 代码块以便捕获 TranslateError 和 ConnectError